### PR TITLE
Move db URL params such that the database engine is set statically, not in the URL

### DIFF
--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,6 +1,6 @@
 # database init, supports mysql too
 database=mysql
-spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
+spring.datasource.url=jdbc:mysql://${MYSQL_URL:localhost/petclinic}
 spring.datasource.username=${MYSQL_USER:petclinic}
 spring.datasource.password=${MYSQL_PASS:petclinic}
 # SQL is written to be idempotent so this is safe

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,5 +1,5 @@
 database=postgres
-spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
+spring.datasource.url=jdbc:postgresql://${POSTGRES_URL:localhost/petclinic}
 spring.datasource.username=${POSTGRES_USER:petclinic}
 spring.datasource.password=${POSTGRES_PASS:petclinic}
 # SQL is written to be idempotent so this is safe


### PR DESCRIPTION
Enforces the jdbc:engine rather than letting anything be specified in the environment variable. This also helps prevent errors if one were to provided EG a postgres jdbc connection string in the MYSQL_URL variable as the application runs some bootstrapping scripts depending on the database value.

Analysis fragment:
```json
{
  "env": [
    {
      "name": "MYSQL_USER",
      "default": "petclinic"
    },
    {
      "name": "MYSQL_URL",
      "default": "localhost/petclinic"
    },
    {
      "name": "MYSQL_PASS",
      "default": "petclinic"
    }
  ],
  "database": [
    {
      "database": null,
      "username": "${MYSQL_USER:petclinic}",
      "password": "${MYSQL_PASS:petclinic}",
      "host": "${MYSQL_URL}",
      "port": null,
      "tls": null,
      "connectionString": "jdbc:mysql://${MYSQL_URL:localhost/petclinic}",
      "engine": "MYSQL"
    }
  ]
}
```